### PR TITLE
Naze32: Fix comments, timer allocation and linker script

### DIFF
--- a/flight/targets/naze32/board-info/board-info.mk
+++ b/flight/targets/naze32/board-info/board-info.mk
@@ -14,11 +14,11 @@ OPENOCD_CONFIG      := stm32f1xx.stlink.cfg
 
 # Note: These must match the values in link_$(BOARD)_memory.ld
 FW_BANK_BASE        := 0x08000000  # Start of firmware flash
-FW_BANK_SIZE        := 0x0001D000  # Should include FW_DESC_SIZE (208kB)
+FW_BANK_SIZE        := 0x0001D000  # Should include FW_DESC_SIZE (116kB)
 
 FW_DESC_SIZE        := 0x00000064
 
-EE_BANK_BASE        := 0x0801D000  # EEPROM storage area (@111kb)
+EE_BANK_BASE        := 0x0801D000  # EEPROM storage area (@116kb)
 EE_BANK_SIZE        := 0x00003000  # Size of EEPROM storage area (12kb)
 
 EF_BANK_BASE        := 0x08000000  # Start of entire flash image (usually start of bootloader as well)

--- a/flight/targets/naze32/board-info/pios_board.h
+++ b/flight/targets/naze32/board-info/pios_board.h
@@ -40,10 +40,10 @@
 /*
 Timer | Channel 1 | Channel 2 | Channel 3 | Channel 4
 ------+-----------+-----------+-----------+----------
-TIM1  |  Servo 4  |           |           |
-TIM2  |  RC In 5  |  RC In 6  |  Servo 6  |
-TIM3  |  Servo 5  |  RC In 2  |  RC In 3  |  RC In 4
-TIM4  |  RC In 1  |  Servo 3  |  Servo 2  |  Servo 1
+TIM1  |  Servo 1  |           |           |  Servo 2
+TIM2  |  RC In 1  |  RC In 2  |  RC In 3  |  RC In 4
+TIM3  |  RC In 5  |  RC In 6  |  RC In 7  |  RC In 8
+TIM4  |  Servo 3  |  Servo 4  |  Servo 5  |  Servo 6
 ------+-----------+-----------+-----------+----------
 */
 
@@ -175,7 +175,7 @@ extern uintptr_t pios_com_mavlink_id;
 #define PIOS_GPIO_CLKS				{  }
 #define PIOS_GPIO_NUM				0
 
-#endif /* STM32103CB_CC_H_ */
+#endif /* STM32103CB_NAZE32_H_ */
 
 /**
  * @}


### PR DESCRIPTION
I'm fairly confident of the linker script comments but not really my area of expertise so worth double checking. :) 

I see the firmware descriptor section is linked into the elf on the Naze rather than using the tlfw mechanism of the other targets. Makes sense since it will usually be flashed using an intel hex copied from the elf at this stage but will need to change this if we end up using the TL bootloader.