### PR TITLE
Naze32: Bump stack sizes to match CC3D, fixes PPM hardfault.

### DIFF
--- a/flight/targets/naze32/fw/pios_config.h
+++ b/flight/targets/naze32/fw/pios_config.h
@@ -95,13 +95,13 @@
 
 /* Task stack sizes */
 #define PIOS_ACTUATOR_STACK_SIZE        800
-#define PIOS_MANUAL_STACK_SIZE          600
+#define PIOS_MANUAL_STACK_SIZE          700
 #define PIOS_SYSTEM_STACK_SIZE          660
 #define PIOS_STABILIZATION_STACK_SIZE   624
 #define PIOS_TELEM_STACK_SIZE           500
 #define PIOS_EVENTDISPATCHER_STACK_SIZE 720
 #define PIOS_MAVLINK_STACK_SIZE         600
-#define PIOS_COMUSBBRIDGE_STACK_SIZE    280
+#define PIOS_COMUSBBRIDGE_STACK_SIZE    296
 #define IDLE_COUNTS_PER_SEC_AT_NO_LOAD 1995998
 
 // This can't be too high to stop eventdispatcher thread overflowing


### PR DESCRIPTION
USB Combridge stack was updated in dc6d2b2cae0f8453fb709f64ac2c8a7477e0f97d.
Manual control stack updated in 881388f058de2569c9bc31dfd0b4663f4a06dee8.